### PR TITLE
add new translate workflow

### DIFF
--- a/.github/workflows/auto_translate.yml
+++ b/.github/workflows/auto_translate.yml
@@ -16,12 +16,12 @@ jobs:
       API_KEY: ${{secrets.DL_API_KEY}}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: dev
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install Translate Tools

--- a/.github/workflows/auto_translate.yml
+++ b/.github/workflows/auto_translate.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Commit to dev
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Increment Version
+          commit_message: autotranslate
           branch: dev

--- a/.github/workflows/auto_translate.yml
+++ b/.github/workflows/auto_translate.yml
@@ -1,11 +1,19 @@
-# This workflow will generate a distribution and upload it to PyPI
-
 name: Auto translate
 on:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'locale/en-us/**'
+      - 'dialog/en-us/**'
+      - 'vocab/en-us/**'
   workflow_dispatch:
 
 jobs:
-  build_and_publish:
+  autotranslate:
+    if: "! contains(toJSON(github.event.commits.*.message), 'autotranslate')"
+    env:
+      API_KEY: ${{secrets.DL_API_KEY}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,7 +26,7 @@ jobs:
           python-version: 3.8
       - name: Install Translate Tools
         run: |
-          python -m pip install git+https://github.com/NeonGeckoCom/neon-lang-plugin-google_translate
+          python -m pip install ovos-translate-plugin-deepl ovos-utils
       - name: Auto Translate
         run: |
           python scripts/translate.py

--- a/.github/workflows/propose_translation.yml
+++ b/.github/workflows/propose_translation.yml
@@ -1,0 +1,55 @@
+name: Propose Translation
+on:
+  workflow_dispatch:
+    inputs:
+      language:
+        type: choice
+        description: Language to translate
+        options:
+          - de-de
+          - ca-es
+          - es-es
+          - cs-cz
+          - fr-fr
+          - it-it
+          - da-dk
+          - nl-nl
+          - hu-hu
+          - pl-pl
+          - pt-pt
+          - ru-ru
+          - sv-fi
+          - sv-se
+          - tr-tr
+
+jobs:
+  Propose_translation:
+    env:
+      TARGET_LANG: ${{ inputs.language }}
+      API_KEY: ${{ secrets.DL_API_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: dev
+        fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install Translate Tools
+      run: |
+        python -m pip install ovos-translate-plugin-deepl ovos-utils
+    - name: Run Translate Script
+      run: python scripts/translate.py
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: autotranslate
+        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        title: Proposed ${{ inputs.language }} Translations
+        body: Translations for review
+        labels: translation
+        branch: staging/translation_${{ inputs.language }}
+        reviewers: emphasize

--- a/.github/workflows/propose_translation.yml
+++ b/.github/workflows/propose_translation.yml
@@ -34,7 +34,7 @@ jobs:
         ref: dev
         fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install Translate Tools

--- a/.github/workflows/propose_translation.yml
+++ b/.github/workflows/propose_translation.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: dev
+        ref: ${{ github.ref_name }}
         fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
     - name: Setup Python
       uses: actions/setup-python@v4

--- a/scripts/translate.py
+++ b/scripts/translate.py
@@ -1,47 +1,131 @@
+from os.path import dirname, join, isdir
+from pathlib import Path
+import shutil
 import os
-from os.path import dirname, join, exists
+import re
 from ovos_utils.bracket_expansion import expand_options
-from googletranslate_neon_plugin import GoogleTranslator
+from ovos_translate_plugin_deepl import DeepLTranslator
 
-tx = GoogleTranslator()
 
-src_lang = "en-us"
-target_langs = ["es-es", "de-de", "fr-fr", "it-it", "pt-pt"]
+API_KEY = os.getenv("API_KEY")
+if not API_KEY:
+    raise ValueError
 
-exts = [".voc", ".dialog", ".intent", ".entity"]
-res_folder = join(dirname(dirname(__file__)), "locale")
-target_langs = list(set(target_langs + os.listdir(res_folder)))
+single_lang = os.getenv("TARGET_LANG")
+target_langs = (single_lang,) if single_lang else ("de-de",
+                                                   "ca-es",
+                                                   "cs-cz",
+                                                   "da-dk",
+                                                   "es-es",
+                                                   "fr-fr",
+                                                   "hu-hu",
+                                                   "it-it",
+                                                   "nl-nl",
+                                                   "pl-pl",
+                                                   "pt-pt",
+                                                   "ru-ru",
+                                                   "sv-fi",
+                                                   "sv-se",
+                                                   "tr-tr")
 
-src_files = {}
-for root, dirs, files in os.walk(res_folder):
+
+base_folder = dirname(dirname(__file__))
+res_folder = join(base_folder, "locale")
+
+# old structure
+old_voc_folder = join(base_folder, "vocab")
+old_dialog_folder = join(base_folder, "dialog")
+old_res_folder = [old_voc_folder, old_dialog_folder]
+
+src_lang="en-us"
+src_files={}
+# note: regex/namedvalues are just copied, this cant be auto translated reliably
+ext = [".voc", ".dialog", ".intent", ".entity", ".rx", ".value"]
+untranslated = [".rx", ".value"]
+
+tx = DeepLTranslator({"api_key": API_KEY})
+
+
+def file_exist(f: str, base: str) -> bool:
+    for root, dirs, files in os.walk(base):
+        if f in files:
+            return True
+    return False
+
+
+def translate(lines: list, target_lang: str) -> list:
+    translations = []
+    for l in lines:
+        expanded = expand_options(l)
+        for l2 in expanded:
+            replacements = dict()
+            for num, var in enumerate(re.findall(r"(?:{{|{)[ a-zA-Z0-9_]*(?:}}|})", l2)):
+                l2 = l2.replace(var, f'@{num}', 1)
+                replacements[f'@{num}'] = var
+            try:
+                translated = tx.translate(l2, target=target_lang, source=src_lang)
+            except Exception as e:
+                continue
+            for num, var in replacements.items():
+                translated = translated.replace(num, var)
+            translations.append(translated)
+
+    return translations
+
+
+def migrate_locale(folder):
+    for lang in os.listdir(folder):
+        path = join(folder, lang)
+        for root, dirs, files in os.walk(path):
+            for file in files:
+                if not file_exist(file, join(res_folder, lang)):
+                    rel_path = root.replace(folder, "").lstrip("/")
+                    new_path = join(res_folder, rel_path)
+                    os.makedirs(new_path, exist_ok=True)
+                    shutil.move(join(root, file),
+                                join(new_path, file))
+        shutil.rmtree(path)
+    shutil.rmtree(folder)
+
+
+for folder in  old_res_folder:
+    if not isdir(folder):
+        continue
+    migrate_locale(folder)
+
+src_folder = join(res_folder, src_lang)
+for root, dirs, files in os.walk(src_folder):
     if src_lang not in root:
         continue
     for f in files:
-        if any(f.endswith(e) for e in exts):
-            src_files[f] = join(root, f)
+        if any(f.endswith(e) for e in ext):
+            file_path = join(root, f)
+            rel_path = file_path.replace(src_folder, "").lstrip("/")
+            src_files[rel_path] = file_path
 
 for lang in target_langs:
-    os.makedirs(join(res_folder, lang), exist_ok=True)
-
-    for name, src in src_files.items():
-        dst = join(res_folder, lang, name)
-        if exists(dst):
+    # service cant translate
+    if not tx.get_langcode(lang):
+        continue
+    for rel_path, src in src_files.items():
+        filename = Path(rel_path).name
+        if file_exist(filename,
+                      join(res_folder, lang)):
             continue
+        os.makedirs(join(res_folder, lang, dirname(rel_path)), exist_ok=True)
 
-        tx_lines = []
         with open(src) as f:
             lines = [l for l in f.read().split("\n") if l and not l.startswith("#")]
-
-        for l in lines:
-            expanded = expand_options(l)
-            for l2 in expanded:
-                try:
-                    translated = tx.translate(l2, target=lang, source=src_lang)
-                    tx_lines.append(translated)
-                except:
-                    continue
-
-        with open(dst, "w") as f:
-            f.write(f"# auto translated from {src_lang} to {lang}\n")
-            for translated in set(tx_lines):
-                f.write(translated + "\n")
+        if any(filename.endswith(e) for e in untranslated):
+            tx_lines = lines
+            is_translated = False
+        else:
+            tx_lines = translate(lines, lang)
+            is_translated = True
+        dst = join(res_folder, lang, rel_path)
+        if tx_lines:
+            with open(dst, "w") as f:
+                if is_translated:
+                    f.write(f"# auto translated from {src_lang} to {lang}\n")
+                for translated in set(tx_lines):
+                    f.write(translated + "\n")


### PR DESCRIPTION
+ improved translate script (+auto migration)

2 workflows:
+ autotranslate on push if `en-us` locales added (likely to be changed later on, but `src_lang` is always `en-us`, so it doesn't make sense triggering on other langs atm)
+ propose translation for a targeted lang to be chosen (workflow dropdown), opens a PR which then can be reviewed appropriately (see [here](https://github.com/OpenVoiceOS/skill-ovos-weather/pull/40))