### PR TITLE
autotranslate workflow refactor

### DIFF
--- a/.github/workflows/auto_translate.yml
+++ b/.github/workflows/auto_translate.yml
@@ -1,17 +1,9 @@
 name: Auto translate
 on:
-  push:
-    branches:
-      - dev
-    paths:
-      - 'locale/en-us/**'
-      - 'dialog/en-us/**'
-      - 'vocab/en-us/**'
   workflow_dispatch:
 
 jobs:
   autotranslate:
-    if: "! contains(toJSON(github.event.commits.*.message), 'autotranslate')"
     env:
       API_KEY: ${{secrets.DL_API_KEY}}
     runs-on: ubuntu-latest

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install Build Tools

--- a/.github/workflows/dev2master.yml
+++ b/.github/workflows/dev2master.yml
@@ -8,7 +8,7 @@ jobs:
   build_and_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
           ref: dev

--- a/.github/workflows/install_tests.yml
+++ b/.github/workflows/install_tests.yml
@@ -20,9 +20,9 @@ jobs:
   plugin_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install test dependencies
@@ -40,9 +40,9 @@ jobs:
   osm_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install ovos dependencies
@@ -57,9 +57,9 @@ jobs:
   msm_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install msm

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -12,9 +12,9 @@ jobs:
   license_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install Build Tools

--- a/.github/workflows/prepare_skillstore.yml
+++ b/.github/workflows/prepare_skillstore.yml
@@ -8,12 +8,12 @@ jobs:
   build_and_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: dev
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install OSM

--- a/.github/workflows/publish_alpha.yml
+++ b/.github/workflows/publish_alpha.yml
@@ -6,9 +6,7 @@ on:
     branches:
       - dev
     paths-ignore:
-      - 'skill_template_repo/version.py'
-      - 'test/**'
-      - 'examples/**'
+      - 'version.py'
       - '.github/**'
       - '.gitignore'
       - 'LICENSE'
@@ -19,35 +17,54 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_publish:
+  autotranslate:
     runs-on: ubuntu-latest
+    env:
+      API_KEY: ${{secrets.DL_API_KEY}} 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: dev
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            locales:
+              - 'locale/en-us/**'
+              - 'dialog/en-us/**'
+              - 'vocab/en-us/**'
+      - name: Setup Python
+        if: steps.filter.outputs.locales == 'true'
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Auto Translate
+        if: steps.filter.outputs.locales == 'true'
+        run: |
+          python -m pip install ovos-translate-plugin-deepl ovos-utils
+          python scripts/translate.py
+      - name: Commit to dev
+        if: steps.filter.outputs.locales == 'true'
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: autotranslate
+          branch: dev
+    
+  build_and_publish:
+    runs-on: ubuntu-latest 
+    steps:
+      - uses: actions/checkout@v3
         with:
           ref: dev
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install Build Tools
         run: |
           python -m pip install build wheel
-      - name: Install Translate Tools
-        run: |
-          python -m pip install git+https://github.com/NeonGeckoCom/neon-lang-plugin-google_translate
-      - name: Install OSM
-        run: |
-          pip install ovos-skills-manager~=0.0.10
-      - name: Migrate old location to "locale" folder
-        run: |
-          python scripts/migrate_locale.py
-      - name: Auto Translate
-        run: |
-          python scripts/translate.py
-      - name: Update Skill Store metadata
-        run: |
-          python scripts/prepare_skillstore.py
       - name: Increment Version
         run: |
           VER=$(python setup.py --version)
@@ -60,7 +77,7 @@ jobs:
       - name: Commit to dev
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Prepare alpha version package
+          commit_message: Increment Version
           branch: dev
       - name: version
         run: echo "::set-output name=version::$(python setup.py --version)"
@@ -78,10 +95,11 @@ jobs:
             ${{ steps.changelog.outputs.changelog }}
           draft: false
           prerelease: true
+          commitish: dev
       - name: Build Distribution Packages
         run: |
           python setup.py bdist_wheel
       - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{secrets.PYPI_TOKEN}}

--- a/.github/workflows/publish_build.yml
+++ b/.github/workflows/publish_build.yml
@@ -8,12 +8,12 @@ jobs:
   build_and_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: dev
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install Build Tools

--- a/.github/workflows/publish_major.yml
+++ b/.github/workflows/publish_major.yml
@@ -8,12 +8,12 @@ jobs:
   build_and_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: dev
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install Build Tools

--- a/.github/workflows/publish_minor.yml
+++ b/.github/workflows/publish_minor.yml
@@ -8,12 +8,12 @@ jobs:
   build_and_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: dev
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install Build Tools

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -38,9 +38,9 @@ jobs:
         python-version: [ 3.7, 3.8, 3.9, "3.10" ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install System Dependencies


### PR DESCRIPTION
Problem:

2 `on_push` workflows (with autotranslate being on of them) side by side was a bad idea.
(using `concurrency` doesn't seem to be an option, at least i don't know how to define priorities within this context)

Autotranslate is now: 
- a job within the Bump Alpha workflow, checking if change were made to the english locale files and only then run the translation script, bumping the version afterwards
- separately an action running on `workflow_dispatch`

also bumps some custom actions